### PR TITLE
Feature/sis 10729 open url redirection logout

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,7 +1,10 @@
 const to = require('await-to-js').default
 const debug = require('debug')('defra.identity:routes')
-const whitelistDomains = [
+const whitelistBackToPathPrefix = [
   `https://${process.env.B2C_TENANT_NAME}.b2clogin.com/`
+]
+const whitelistBackToPathReturnUrl = [
+  `post_logout_redirect_uri=${process.env.APPLICATION_DOMAIN_URL}/business/finaliselogout`
 ]
 
 module.exports = ({
@@ -86,7 +89,10 @@ module.exports = ({
         const { query: { backToPath } } = request
         const redirectPath = backToPath || '/'
 
-        if (!whitelistDomains.some(entry => redirectPath.startsWith(entry))) {
+        if (
+          !whitelistBackToPathPrefix.some(entry => redirectPath.startsWith(entry)) ||
+          !whitelistBackToPathReturnUrl.some(entry => redirectPath.endsWith(entry))
+        ) {
           throw new Error('Return path not allowed')
         }
 


### PR DESCRIPTION
## Ticket
[[KITS RETEST] Open URL Redirection - The application accepted user-controlled input that specifies a link to an external site, and uses that link to redirect the user's browser.](https://vmddefra.atlassian.net/browse/SIS-10729)

## Description
The `backToPath` parameter is actually this...

https://vmdcustomer.b2clogin.com/vmdcustomer.onmicrosoft.com/oauth2/v2.0/logout?p=b2c_1a_signup_signin&post_logout_redirect_uri=http://localhost:3200/business/finaliselogout

So we need to check the `post_logout_redirect_uri` parameter of this path is not malicious. Not sure if the previous check is having any effect, but leaving for now rather than risk re-introducing another vulnerability

## Developer notes
Following this merge, I will raise an applications pr to update the package-lock commit hashes in SM, MMB & MA